### PR TITLE
Fix key order on ingress for testing cert-manager certificate issuer

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,7 +716,7 @@ k8s:
 **Warning**: Be sure that your DNS name is valid/pointing to the correct machine before doing that, as it is easy to be blacklisted/throttled by let's encrypt. Especially if you are using DNS challenge for getting wildcard certificates.
 
 If you configured everything correctly editing our previous ingress and adding
-a cluster issuer annotation and a TLS section in the spec is enough.
+a cluster issuer annotation, a TLS section in the spec and a host in the rules is enough.
 ```yaml
 ---
 apiVersion: extensions/v1beta1
@@ -732,7 +732,8 @@ spec:
     - domain.name
     secretName: test-tls
   rules:
-  - http:
+  - host: domain.name # here
+    http:
       paths:
       - path: /
         backend:

--- a/README.md
+++ b/README.md
@@ -727,11 +727,11 @@ metadata:
     kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: "letsencrypt-prod" #Here
 spec:
-  rules:
   tls: # here
   - hosts:
     - domain.name
     secretName: test-tls
+  rules:
   - http:
       paths:
       - path: /


### PR DESCRIPTION
The `tls:` section was added below the `rules:` section, which makes the section empty and therefore invalid.

Also, we need a `host:` section inside the `rules:`, or else we'll only get a self-signed certificate.