### PR TITLE
Fix `pgp` rule in `.sops.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ To use it, create a config file at the root of your repository
 ```bash
 ❯ cat .sops.yaml
 creation_rules:
-    - gpg: >-
+    - pgp: >-
         YOUR_PGP_FINGERPRINT_WITHOUT_SPACE
 ```
 


### PR DESCRIPTION
Should be `pgp` instead of `gpg`.