### PR TITLE
Replace --no-deploy with --disable during k3s installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ iptables:
 	ssh ${HOST} 'chmod +x /etc/network/if-pre-up.d/iptables-restore && sh /etc/network/if-pre-up.d/iptables-restore'
 	
 kubernetes_install:
-	ssh ${HOST} 'export INSTALL_K3S_EXEC=" --no-deploy servicelb --no-deploy traefik --no-deploy local-storage --disable-cloud-controller --disable-network-policy --advertise-address 10.200.200.1 "; \
+	ssh ${HOST} 'export INSTALL_K3S_EXEC=" --disable servicelb --disable traefik --disable local-storage --disable-cloud-controller --disable-network-policy --advertise-address 10.200.200.1 "; \
 		curl -sfL https://get.k3s.io | sh -'
 	#ssh ${HOST} "cat /etc/systemd/system/k3s.service" | diff  - k8s/k3s.serivce \
 		|| (scp k8s/k3s.service ${HOST}:/etc/systemd/system/k3s.serviceg && ssh ${HOST} 'systemctl daemon-reload && systemctl restart k3s.service')

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ The main benefit of having Kubernetes installed on my server, is that it allow m
 Let's start, to install K3s nothing more complicated than
 ```bash
 kubernetes_install:
-        ssh ${HOST} 'export INSTALL_K3S_EXEC=" --no-deploy servicelb --no-deploy traefik --no-deploy local-storage"; \
+        ssh ${HOST} 'export INSTALL_K3S_EXEC=" --disable servicelb --disable traefik --disable local-storage"; \
                 curl -sfL https://get.k3s.io | sh -'
 ```
 


### PR DESCRIPTION
### Issue: 

```
k3s.service - Lightweight Kubernetes
     Loaded: loaded (/etc/systemd/system/k3s.service; enabled; vendor preset: enabl>     Active: activating (auto-restart) (Result: exit-code) since Wed 2022-11-23 14:>       Docs: https://k3s.io
    Process: 1593 ExecStartPre=/bin/sh -xc ! /usr/bin/systemctl is-enabled --quiet >    Process: 1595 ExecStartPre=/sbin/modprobe br_netfilter (code=exited, status=0/S>    Process: 1596 ExecStartPre=/sbin/modprobe overlay (code=exited, status=0/SUCCES>    Process: 1597 ExecStart=/usr/local/bin/k3s server --no-deploy servicelb --no-de>   Main PID: 1597 (code=exited, status=1/FAILURE)
        CPU: 228ms
```

```
Nov 23 14:27:09 mydomain.gr systemd[1]: k3s.service: Consumed 5.116s CPU time.
Nov 23 14:27:14 mydomain.gr systemd[1]: k3s.service: Scheduled restart job, restart counter is at 1.
Nov 23 14:27:14 mydomain.gr systemd[1]: Stopped Lightweight Kubernetes.
Nov 23 14:27:14 mydomain.gr systemd[1]: k3s.service: Consumed 5.116s CPU time.
Nov 23 14:27:14 mydomain.gr systemd[1]: Starting Lightweight Kubernetes...
Nov 23 14:27:14 mydomain.gr sh[1484]: + /usr/bin/systemctl is-enabled --quiet nm-cloud-setup.service
Nov 23 14:27:14 mydomain.gr sh[1485]: Failed to get unit file state for nm-cloud-setup.service: No such file or directory
Nov 23 14:27:14 mydomain.gr k3s[1488]: time="2022-11-23T14:27:14+02:00" level=fatal msg="no-deploy flag is deprecated. Use --disable instead."
Nov 23 14:27:14 mydomain.gr systemd[1]: k3s.service: Main process exited, code=exited, status=1/FAILURE
Nov 23 14:27:14 mydomain.gr systemd[1]: k3s.service: Failed with result 'exit-code'.
Nov 23 14:27:14 mydomain.gr systemd[1]: Failed to start Lightweight Kubernetes.
```

### Cause:
```
Nov 23 14:27:14 mydomain.gr k3s[1488]: time="2022-11-23T14:27:14+02:00" level=fatal msg="no-deploy flag is deprecated. Use --disable instead."
```

### Expected behaviour:
```
[INFO]  systemd: Starting k3s
$ sudo systemctl status k3s.service
● k3s.service - Lightweight Kubernetes
     Loaded: loaded (/etc/systemd/system/k3s.service; enabled; vendor preset: enabled)
     Active: active (running)
```

### Fix:

```
export INSTALL_K3S_EXEC=" --disable servicelb --disable traefik --disable local-storage";
curl -sfL https://get.k3s.io | sh -
```

OS: Debian 11 Stable
Date: 2022-11-23

### How to reproduce:

Try installing the install script at get.k3s.io with the `--no-deploy` flags instead of `--disable` flags 

